### PR TITLE
Improve dashboard layout and add phalo color

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 export default function AboutPage() {
   return (
-    <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden">
+    <div className="relative min-h-screen font-sans bg-phalo overflow-hidden">
       {/* Background gradient and noise overlay */}
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -102,9 +102,6 @@ export default function AboutPage() {
         </div>
       </div>
       
-      <style jsx global>{`
-        .bg-phalo-green { background: #123c2b; }
-      `}</style>
     </div>
   );
 } 

--- a/src/app/dashboard/analytics/page.tsx
+++ b/src/app/dashboard/analytics/page.tsx
@@ -13,7 +13,7 @@ export default function AnalyticsPage() {
 
   if (!isSignedIn) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -24,25 +24,19 @@ export default function AnalyticsPage() {
           <Link href="/" className="text-white/70 hover:text-white underline lowercase">go back to home</Link>
         </div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
 
   if (isLoading) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
         
         <div className="relative z-10 text-white lowercase">loading...</div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
@@ -50,7 +44,7 @@ export default function AnalyticsPage() {
   const monetizedRepos = repositories?.filter((r: { is_monetized: boolean; id: string; full_name: string }) => r.is_monetized) || [];
 
   return (
-    <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden">
+    <div className="relative min-h-screen font-sans bg-phalo overflow-hidden">
       {/* Background gradient and noise overlay */}
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -153,9 +147,6 @@ export default function AnalyticsPage() {
         </div>
       </div>
       
-      <style jsx global>{`
-        .bg-phalo-green { background: #123c2b; }
-      `}</style>
     </div>
   );
 }

--- a/src/app/dashboard/campaigns/page.tsx
+++ b/src/app/dashboard/campaigns/page.tsx
@@ -72,7 +72,7 @@ export default function CampaignsPage() {
 
   if (!isSignedIn) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -83,31 +83,25 @@ export default function CampaignsPage() {
           <Link href="/" className="text-white/70 hover:text-white underline lowercase">go back to home</Link>
         </div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
 
   if (isLoading) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
         
         <div className="relative z-10 text-white lowercase">loading...</div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
 
   return (
-    <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden">
+    <div className="relative min-h-screen font-sans bg-phalo overflow-hidden">
       {/* Background gradient and noise overlay */}
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -309,7 +303,6 @@ export default function CampaignsPage() {
       </div>
       
       <style jsx global>{`
-        .bg-phalo-green { background: #123c2b; }
       `}</style>
     </div>
   );

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,18 +1,10 @@
 'use client';
 
-import { UserButton, useUser } from '@clerk/nextjs';
-import Link from 'next/link';
-import { useRouter, usePathname } from 'next/navigation';
+import { useUser } from '@clerk/nextjs';
+import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
+import { LayoutProvider } from '@/components/layout/layout-provider';
 
-// Navigation items
-const navigation = [
-  { name: 'Dashboard', href: '/dashboard' },
-  { name: 'Repositories', href: '/dashboard/repositories' },
-  { name: 'Analytics', href: '/dashboard/analytics' },
-  { name: 'Payouts', href: '/dashboard/payouts' },
-  { name: 'Settings', href: '/settings' },
-];
 
 export default function DashboardLayout({
   children,
@@ -21,7 +13,6 @@ export default function DashboardLayout({
 }) {
   const { isLoaded, isSignedIn } = useUser();
   const router = useRouter();
-  const pathname = usePathname();
 
   useEffect(() => {
     if (isLoaded && !isSignedIn) {
@@ -38,104 +29,10 @@ export default function DashboardLayout({
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-14">
-            <div className="flex items-center space-x-8">
-              {/* Logo with home link */}
-              <div className="flex items-center space-x-4">
-                <Link 
-                  href="/" 
-                  className="text-sm text-gray-500 hover:text-gray-700 transition-colors duration-200 flex items-center"
-                  title="Back to home"
-                >
-                  <svg className="w-4 h-4 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6" />
-                  </svg>
-                  Home
-                </Link>
-                <span className="text-gray-300">|</span>
-                <Link href="/dashboard" className="text-xl font-semibold text-gray-900 hover:text-gray-700 transition-colors duration-200">
-                  monetizeG
-                </Link>
-              </div>
-              
-              {/* Navigation */}
-              <nav className="hidden md:flex space-x-1">
-                {navigation.map((item) => {
-                  const isActive = pathname === item.href;
-                  return (
-                    <Link
-                      key={item.name}
-                      href={item.href}
-                      className={`
-                        px-3 py-2 rounded-md text-sm font-medium transition-all duration-200
-                        ${isActive 
-                          ? 'bg-gray-100 text-gray-900 shadow-sm' 
-                          : 'text-gray-600 hover:text-gray-900 hover:bg-gray-50'
-                        }
-                      `}
-                    >
-                      {item.name}
-                    </Link>
-                  );
-                })}
-              </nav>
-            </div>
-            
-            {/* User section */}
-            <div className="flex items-center space-x-4">
-              <div className="hidden sm:block">
-                <UserButton 
-                  afterSignOutUrl="/" 
-                  appearance={{
-                    elements: {
-                      avatarBox: "w-8 h-8",
-                      userButtonPopoverCard: "bg-white border border-gray-200 shadow-lg",
-                    }
-                  }}
-                />
-              </div>
-              
-              {/* Mobile menu button */}
-              <div className="md:hidden">
-                <UserButton afterSignOutUrl="/" />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Mobile navigation */}
-        <div className="md:hidden border-t border-gray-200 bg-gray-50">
-          <div className="px-2 pt-2 pb-3 space-y-1">
-            {navigation.map((item) => {
-              const isActive = pathname === item.href;
-              return (
-                <Link
-                  key={item.name}
-                  href={item.href}
-                  className={`
-                    block px-3 py-2 rounded-md text-base font-medium transition-all duration-200
-                    ${isActive 
-                      ? 'bg-white text-gray-900 shadow-sm border border-gray-200' 
-                      : 'text-gray-600 hover:text-gray-900 hover:bg-white'
-                    }
-                  `}
-                >
-                  {item.name}
-                </Link>
-              );
-            })}
-          </div>
-        </div>
-      </header>
-
-      {/* Main content with reduced padding */}
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+    <LayoutProvider showSidebar>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
         {children}
-      </main>
-    </div>
+      </div>
+    </LayoutProvider>
   );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -17,7 +17,7 @@ export default function DashboardPage() {
 
   if (!isSignedIn) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -28,31 +28,25 @@ export default function DashboardPage() {
           <Link href="/" className="text-white/70 hover:text-white underline lowercase">go back to home</Link>
         </div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
 
   if (isLoading) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
         
         <div className="relative z-10 text-white lowercase">loading...</div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
 
   return (
-    <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden">
+    <div className="relative min-h-screen font-sans bg-phalo overflow-hidden">
       {/* Background gradient and noise overlay */}
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -192,9 +186,6 @@ export default function DashboardPage() {
         </div>
       </div>
       
-      <style jsx global>{`
-        .bg-phalo-green { background: #123c2b; }
-      `}</style>
     </div>
   );
 }

--- a/src/app/dashboard/payouts/page.tsx
+++ b/src/app/dashboard/payouts/page.tsx
@@ -37,7 +37,7 @@ export default function PayoutsPage() {
 
   if (!isSignedIn) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -48,25 +48,19 @@ export default function PayoutsPage() {
           <Link href="/" className="text-white/70 hover:text-white underline lowercase">go back to home</Link>
         </div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
 
   if (isLoading) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
         
         <div className="relative z-10 text-white lowercase">loading...</div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
@@ -75,7 +69,7 @@ export default function PayoutsPage() {
   const canRequestPayout = availableBalance >= 50; // $50 minimum
 
   return (
-    <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden">
+    <div className="relative min-h-screen font-sans bg-phalo overflow-hidden">
       {/* Background gradient and noise overlay */}
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -244,7 +238,6 @@ export default function PayoutsPage() {
       </div>
       
       <style jsx global>{`
-        .bg-phalo-green { background: #123c2b; }
       `}</style>
     </div>
   );

--- a/src/app/dashboard/repositories/page.tsx
+++ b/src/app/dashboard/repositories/page.tsx
@@ -192,7 +192,7 @@ export default function RepositoriesPage() {
 
   if (!isSignedIn) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -203,31 +203,25 @@ export default function RepositoriesPage() {
           <Link href="/" className="text-white/70 hover:text-white underline lowercase">go back to home</Link>
         </div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
 
   if (isLoading) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
         
         <div className="relative z-10 text-white lowercase">loading...</div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
 
   return (
-    <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden">
+    <div className="relative min-h-screen font-sans bg-phalo overflow-hidden">
       {/* Background gradient and noise overlay */}
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -476,7 +470,6 @@ export default function RepositoriesPage() {
       </div>
       
       <style jsx global>{`
-        .bg-phalo-green { background: #123c2b; }
       `}</style>
     </div>
   );

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -40,7 +40,7 @@ export default function PricingPage() {
   };
 
   return (
-    <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden">
+    <div className="relative min-h-screen font-sans bg-phalo overflow-hidden">
       {/* Background gradient and noise overlay */}
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -263,9 +263,6 @@ export default function PricingPage() {
         </div>
       </div>
       
-      <style jsx global>{`
-        .bg-phalo-green { background: #123c2b; }
-      `}</style>
     </div>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -22,7 +22,7 @@ export default function SettingsPage() {
 
   if (!isSignedIn) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -33,31 +33,25 @@ export default function SettingsPage() {
           <Link href="/" className="text-white/70 hover:text-white underline lowercase">go back to home</Link>
         </div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
 
   if (isLoading) {
     return (
-      <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden flex items-center justify-center">
+      <div className="relative min-h-screen font-sans bg-phalo overflow-hidden flex items-center justify-center">
         {/* Background gradient and noise overlay */}
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
         <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
         
         <div className="relative z-10 text-white lowercase">loading...</div>
         
-        <style jsx global>{`
-          .bg-phalo-green { background: #123c2b; }
-        `}</style>
       </div>
     );
   }
 
   return (
-    <div className="relative min-h-screen font-sans bg-phalo-green overflow-hidden">
+    <div className="relative min-h-screen font-sans bg-phalo overflow-hidden">
       {/* Background gradient and noise overlay */}
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0" style={{background: 'radial-gradient(ellipse at 60% 40%, #1c3c36 0%, #0e1e1a 100%)'}} />
       <div aria-hidden className="pointer-events-none fixed inset-0 z-0 mix-blend-overlay opacity-60" style={{backgroundImage: 'url(https://grainy-gradients.vercel.app/noise.svg)'}} />
@@ -223,9 +217,6 @@ export default function SettingsPage() {
         </div>
       </div>
       
-      <style jsx global>{`
-        .bg-phalo-green { background: #123c2b; }
-      `}</style>
     </div>
   );
 }

--- a/src/lib/security-monitor.ts
+++ b/src/lib/security-monitor.ts
@@ -78,7 +78,7 @@ export class SecurityMonitor {
     }
 
     // Check for patterns that require immediate action
-    this.checkForSuspiciousPatterns(event.ip, event.type);
+    this.checkForSuspiciousPatterns(event.ip);
   }
 
   private static sendToMonitoringService(event: SecurityEvent) {
@@ -87,7 +87,7 @@ export class SecurityMonitor {
     console.error('Security Event (Production):', JSON.stringify(event));
   }
 
-  private static checkForSuspiciousPatterns(ip: string, _eventType: SecurityEventType) {
+  private static checkForSuspiciousPatterns(ip: string) {
     const recentEvents = securityEvents.filter(
       event => event.ip === ip && 
       Date.now() - event.timestamp.getTime() < 15 * 60 * 1000 // Last 15 minutes

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,0 +1,18 @@
+import { type Config } from 'tailwindcss'
+
+const config = {
+  darkMode: ['class'],
+  content: [
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        phalo: '#123c2b'
+      }
+    }
+  },
+  plugins: []
+} satisfies Config
+
+export default config


### PR DESCRIPTION
## Summary
- wrap dashboard pages with `LayoutProvider`
- remove inline phalo-green styles
- add `phalo` color token in Tailwind config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843b09cd694833189e8ba4f525268af

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Unified background color styling across multiple pages by replacing the "bg-phalo-green" class with "bg-phalo".
  - Removed the custom "bg-phalo-green" background color and its associated CSS from all affected pages.
  - Introduced a new Tailwind CSS configuration with a custom "phalo" color for consistent theming.

- **Refactor**
  - Simplified the dashboard layout by delegating navigation and header rendering to a layout provider component.

- **Chores**
  - Updated Tailwind configuration to scan relevant files and enable dark mode via class toggle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->